### PR TITLE
Following the formula page 11 of the paper "Solution Sampling with Ra…

### DIFF
--- a/src/main/java/org/mvavrill/tableSampling/plotting/StatisticalTests.java
+++ b/src/main/java/org/mvavrill/tableSampling/plotting/StatisticalTests.java
@@ -80,7 +80,7 @@ public class StatisticalTests {
   public double[] getAverageCounts(final int nbSolutions, final int nbSamples) { 
     double[] solutionAverage = new double[nbSolutions];
     for (int i = 0; i < nbSolutions; i++)
-      solutionAverage[i] = (double)nbSolutions / nbSamples;
+      solutionAverage[i] = (double) nbSamples/ nbSolutions;
     return solutionAverage;
   }
 


### PR DESCRIPTION
…ndom Table Constraints", it is the ratio nbSample/nbSolution which is used in the p-value computation. Same when looking at the TestUtils.chiSquareTest method documentation: first term is expectations, i.e. how many of the samples should be this solution, i.e. nbSample/nbSol